### PR TITLE
Update betterReadingMarker.ts support with korean

### DIFF
--- a/src/betterReadingMarker.ts
+++ b/src/betterReadingMarker.ts
@@ -57,7 +57,7 @@ function isInsidePre(node: Node) {
 export const rules: HighlightRule[] = [
     {
         regexMode: 'gu',
-        regexPattern: '\\b[\\p{L}\\p{Alphabetic}\\p{Mark}\\p{Connector_Punctuation}\\p{Join_Control}\\p{Script_Extensions=Han}\\p{Script_Extensions=Hiragana}\\p{Script_Extensions=Katakana}]+\\b', // 正则表达式，匹配单词
+		regexPattern: '\\b[\\p{L}\\p{Alphabetic}\\p{Mark}\\p{Connector_Punctuation}\\p{Join_Control}\\p{Script=Hangul}\\p{Script_Extensions=Han}\\p{Script_Extensions=Hiragana}\\p{Script_Extensions=Katakana}]+\\b',
         creator: (word) => {
             let boldLength = 0;
             const wordLength = word.trim().length;


### PR DESCRIPTION
to
regexPattern: '\\b[\\p{L}\\p{Alphabetic}\\p{Mark}\\p{Connector_Punctuation}\\p{Join_Control}\\p{Script=Hangul}\\p{Script_Extensions=Han}\\p{Script_Extensions=Hiragana}\\p{Script_Extensions=Katakana}]+\\b',