### PR TITLE
Update betterReadingMarker.ts with properly support with korean

### DIFF
--- a/src/betterReadingMarker.ts
+++ b/src/betterReadingMarker.ts
@@ -57,8 +57,8 @@ function isInsidePre(node: Node) {
 export const rules: HighlightRule[] = [
     {
         regexMode: 'gu',
-		regexPattern: '\\b[\\p{L}\\p{Alphabetic}\\p{Mark}\\p{Connector_Punctuation}\\p{Join_Control}\\p{Script=Hangul}\\p{Script_Extensions=Han}\\p{Script_Extensions=Hiragana}\\p{Script_Extensions=Katakana}]+\\b',
-        creator: (word) => {
+        regexPattern: '[\\p{L}\\p{Alphabetic}\\p{Mark}\\p{Connector_Punctuation}\\p{Join_Control}\\p{Script_Extensions=Han}\\p{Script_Extensions=Hiragana}\\p{Script_Extensions=Katakana}]+|[\\uAC00-\\uD7AF]+',
+		creator: (word) => {
             let boldLength = 0;
             const wordLength = word.trim().length;
 

--- a/src/betterReadingWidget.ts
+++ b/src/betterReadingWidget.ts
@@ -71,7 +71,7 @@ export function betterReadingExtension(app: App, plugin: betterReadingPlugin) {
 				for (let part of view.visibleRanges) {
 					let betterReadingCursor: RegExpCursor | SearchCursor;
 					try {
-						betterReadingCursor = new RegExpCursor(state.doc, "[a-zA-Z\\u0400-\\u04FF]+", {}, part.from, part.to);
+						betterReadingCursor = new RegExpCursor(state.doc, "[a-zA-Z\\u0400-\\u04FF\\uAC00-\\uD7AF]+", {}, part.from, part.to);
 					} catch (err) {
 						console.debug(err);
 						continue;


### PR DESCRIPTION
https://github.com/Quorafind/Obsidian-Better-Reading-Mode/issues/14

I used unicode way(instaed of Hangul) to checking peroperly with korean support, 

|[\\uAC00-\\uD7AF]


and it is working perfectly fine now

![image](https://github.com/Quorafind/Obsidian-Better-Reading-Mode/assets/14916432/a791fa5f-fcfa-4ad7-96d3-ea0e9512780b)
