### PR TITLE
fix: Remove eq method and comment out its logic

### DIFF
--- a/src/betterReadingWidget.ts
+++ b/src/betterReadingWidget.ts
@@ -15,20 +15,20 @@ class BetterReadingWidget extends WidgetType {
 		super();
 	}
 
-	eq(other: BetterReadingWidget) {
-		const markdownView = app.workspace.getActiveViewOfType(MarkdownView);
-		if (!markdownView) {
-			return;
-		}
-
-		const editor = markdownView.editor;
-		const offset = editor.offsetToPos(this.from);
-		const originalOffset = editor.offsetToPos(other.from);
-		if (offset.line === originalOffset.line) {
-			return true;
-		}
-		return other.view === this.view && other.from === this.from && other.to === this.to;
-	}
+	// eq(other: BetterReadingWidget) {
+	// 	const markdownView = app.workspace.getActiveViewOfType(MarkdownView);
+	// 	if (!markdownView) {
+	// 		return;
+	// 	}
+	//
+	// 	const editor = markdownView.editor;
+	// 	const offset = editor.offsetToPos(this.from);
+	// 	const originalOffset = editor.offsetToPos(other.from);
+	// 	if (offset.line === originalOffset.line) {
+	// 		return true;
+	// 	}
+	// 	return other.view === this.view && other.from === this.from && other.to === this.to;
+	// }
 
 	toDOM() {
 		return createSpan('cm-better-reading');


### PR DESCRIPTION
The eq method has been commented out as it appears unused and was breaking the plugin’s functionality on my installation.