### PR TITLE
Fix vulnerabilities detected with npm audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# Exclude package-lock.json
+package-lock.json

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,7 +11,7 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = (process.argv[2] === 'production');
 
-esbuild.build({
+const context = esbuild.context({
 	banner: {
 		js: banner,
 	},
@@ -46,10 +46,20 @@ esbuild.build({
 		'@lezer/lr',
 		...builtins],
 	format: 'cjs',
-	watch: !prod,
 	target: 'es2016',
 	logLevel: "info",
 	sourcemap: prod ? false : 'inline',
 	treeShaking: true,
 	outfile: 'main.js',
-}).catch(() => process.exit(1));
+});
+
+if (prod) {
+	context.then(() => {
+		console.log("build complete");
+		process.exit(0);
+	}).catch(() => process.exit(1));
+} else {
+	context.then((ctx) => {
+		ctx.watch();
+	});
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "better-reading-mode",
-	"name": "Better Reading Mode",
+	"id": "better-reading-mode-dev",
+	"name": "Better Reading Mode DEV",
 	"version": "1.2.2",
 	"minAppVersion": "0.15.2",
 	"description": "A plugin to enable better reading mode in Live preview mode of Obsidian, which works similar to bionic reading mode.",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "better-reading-mode-dev",
-	"name": "Better Reading Mode DEV",
+	"id": "better-reading-mode",
+	"name": "Better Reading Mode",
 	"version": "1.2.2",
 	"minAppVersion": "0.15.2",
 	"description": "A plugin to enable better reading mode in Live preview mode of Obsidian, which works similar to bionic reading mode.",

--- a/package.json
+++ b/package.json
@@ -8,31 +8,32 @@
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"bumpversion": "node version-bump.mjs && git add manifest.json versions.json"
 	},
-	"keywords": ["Bionic reading", "Obsidian"],
+	"keywords": [
+		"Bionic reading",
+		"Obsidian"
+	],
 	"author": "Boninall",
 	"license": "MIT",
 	"devDependencies": {
 		"@codemirror/autocomplete": "^6.0.0",
 		"@codemirror/commands": "^6.0.0",
-		"@codemirror/lang-html": "^6.0.0",
-		"@codemirror/basic-setup": "^0.20.0",
 		"@codemirror/lang-css": "^6.0.0",
+		"@codemirror/lang-html": "^6.0.0",
 		"@codemirror/language": "https://github.com/lishid/cm-language",
-		"@codemirror/rangeset": "^0.19.1",
 		"@codemirror/lint": "^6.0.0",
 		"@codemirror/search": "^6.0.0",
 		"@codemirror/state": "^6.0.0",
-		"@codemirror/view": "^6.0.0",
 		"@codemirror/stream-parser": "https://github.com/lishid/stream-parser",
-		"codemirror": "^6.0.0",
+		"@codemirror/view": "^6.0.0",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "^5.2.0",
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
-		"esbuild": "0.13.12",
+		"codemirror": "^6.0.0",
+		"esbuild": "^0.27.0",
 		"obsidian": "latest",
+		"regexp-match-indices": "^1.0.2",
 		"tslib": "2.4.0",
-		"typescript": "4.7.3",
-		"regexp-match-indices": "^1.0.2"
+		"typescript": "4.7.3"
 	}
 }

--- a/src/betterReadingMarker.ts
+++ b/src/betterReadingMarker.ts
@@ -92,7 +92,7 @@ function replaceTextWithElements(app: App, node: Node, rules: HighlightRule[]) {
             while ((match = regex.exec(textContent)) !== null) {
                 const part = match[0];
 
-                console.log(part);
+                //console.log(part);
 
                 const precedingText = textContent.substring(lastIndex, match.index);
                 newTextContent += precedingText;
@@ -108,7 +108,7 @@ function replaceTextWithElements(app: App, node: Node, rules: HighlightRule[]) {
 
         const parser = new DOMParser();
         const doc = parser.parseFromString(textContent, "text/html");
-        console.log(doc.body.childNodes);
+        //console.log(doc.body.childNodes);
         Array.from(doc.body.childNodes).forEach((newNode) => {
             if (newNode.nodeName === "#text") {
                 node.parentNode?.insertBefore(newNode.cloneNode(true), node);


### PR DESCRIPTION
```
npm audit report

esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
Will install esbuild@0.27.0, which is a breaking change
node_modules/esbuild

1 moderate severity vulnerability
```
With `npm audit fix --force` dependencies are updated.

Minor update for `npm run dev` watch is colling without errors now.